### PR TITLE
Pass `cParent` into `luaifyValueWithType`

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -209,7 +209,8 @@ def stripSizeOf(s):
   return s
 
 # converts a c value to a lua value - used for optional arguments
-def luaifyValueWithType(t, s):
+def luaifyValueWithType(p, s):
+  t = p.type
   k = t.kind
   #print(" === luaifyValue ")
   #print(" k = "+ str(k))
@@ -236,14 +237,15 @@ def luaifyValueWithType(t, s):
   elif k == TyK.TYPEDEF:
     # Need to dereference typedefs to ensure the correct lua code gets generated
     underlying_type = t.get_canonical()
-    return luaifyValueWithType(underlying_type, s)
+    p.type = underlying_type
+    return luaifyValueWithType(p, s)
   else:
-    print("unknown value type: ", k, s, ' ### parent = ', cParent.type.spelling, ' ', cParent.spelling)
+    print("unknown value type: ", k, s, ' ### parent = ', t.spelling, ' ', p.spelling)
   return s
 
 # converts a c value to a lua value - used for optional arguments
 def luaifyValue(cParent, s):
-  return luaifyValueWithType(cParent.type, s)
+  return luaifyValueWithType(cParent, s)
 
 def getLuaFunctionOptionalParams(c):
   parameter_opt = None


### PR DESCRIPTION
Fixes an error regarding `cParent` not being passed into a function.
```
  File "F:\Development\ALIM-Framework\ALIM-Core\Tools\ImGuiLuaGen\gen.py", line 241, in luaifyValueWithType
    print("unknown value type: ", k, s, ' ### parent = ', cParent.type.spelling, ' ', cParent.spelling)
NameError: name 'cParent' is not defined
```

Others will be able to use it without having to worry about it now.

And this is unrelated to this PR, but I've had to manually change some bits to make it work with my project, I've finally got it working though. I'll make another PR shortly when I'm not busy with other things. And thank you for making this public, I had already made one (well, was WIP but it worked), but this one is better.